### PR TITLE
Fix https://github.com/panubo/docker-vsftpd/issues/2

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -15,7 +15,7 @@ fi
 
 # Support multiple users
 while read user; do
-	IFS=: read name pass <<< ${!user}
+	IFS=: read name pass <<< "${!user}"
 	echo "Adding user $name"
 	/add-virtual-user.sh "$name" "$pass"
 done < <(env | grep "FTP_USER_" | sed 's/^\(FTP_USER_[a-zA-Z0-9]*\)=.*/\1/')


### PR DESCRIPTION
The combination of IFS and an unquoted Here String was causing `read` to
put both values into the first variable (name).